### PR TITLE
Force listfile.txt to always only have LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+listfile.txt text eol=lf


### PR DESCRIPTION
This should do it for line endings I hope